### PR TITLE
💥 Convert package to ESM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Node CI
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        node: [12.20.0, 14.13.1, 16.0.0]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node }}
+    - name: Install dependencies
+      run: npm install
+    - name: Run tests
+      run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /node_modules/
-/npm-debug.log

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,2 @@
-declare function rmFile(path: string): Promise<void>
-
-declare namespace rmFile {
-  export function sync(path: string): void
-}
-
-export = rmFile
+export function rmFile(path: string | Buffer | URL): Promise<void>
+export function rmFileSync(path: string | Buffer | URL): void

--- a/index.js
+++ b/index.js
@@ -1,8 +1,5 @@
-'use strict'
-
-const fs = require('fs')
-
-const NestedError = require('nested-error-stacks')
+import fs from 'node:fs'
+import NestedError from 'nested-error-stacks'
 
 class RmFileError extends NestedError {
   constructor (message, nested) {
@@ -12,30 +9,29 @@ class RmFileError extends NestedError {
   }
 }
 
-function createError (err, path) {
-  switch (err.code) {
+function createError (error, path) {
+  switch (error.code) {
     case 'ENOENT':
-      return new RmFileError(`No file could be found at "${path}"`, err)
+      return new RmFileError(`No file could be found at "${path}"`, error)
     case 'ENOTDIR':
-      return new RmFileError(`A component used as a directory in "${path}" is not, in fact, a directory`, err)
+      return new RmFileError(`A component used as a directory in "${path}" is not, in fact, a directory`, error)
     default:
-      return new RmFileError(`Failed to remove file "${path}"`, err)
+      return new RmFileError(`Failed to remove file "${path}"`, error)
   }
 }
 
-module.exports = function rmFile (path) {
-  return new Promise((resolve, reject) => {
-    fs.unlink(path, err => {
-      if (err) reject(createError(err, path))
-      resolve()
-    })
-  })
+export async function rmFile (path) {
+  try {
+    await fs.promises.unlink(path)
+  } catch (error) {
+    throw createError(error, path)
+  }
 }
 
-module.exports.sync = function rmFileSync (path) {
+export function rmFileSync (path) {
   try {
     fs.unlinkSync(path)
-  } catch (err) {
-    throw createError(err, path)
+  } catch (error) {
+    throw createError(error, path)
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,15 +3,20 @@
   "version": "1.2.0",
   "license": "MIT",
   "repository": "LinusU/rm-file",
+  "type": "module",
+  "exports": "./index.js",
   "scripts": {
-    "test": "standard && mocha"
+    "test": "standard && mocha && ts-readme-generator --check"
   },
   "dependencies": {
-    "nested-error-stacks": "^2.0.0"
+    "nested-error-stacks": "^2.1.0"
   },
   "devDependencies": {
-    "assert-rejects": "^0.1.1",
-    "mocha": "^5.2.0",
-    "standard": "^11.0.1"
+    "mocha": "^9.1.0",
+    "standard": "^16.0.3",
+    "ts-readme-generator": "^0.6.1"
+  },
+  "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -14,26 +14,29 @@ npm install --save rm-file
 ## Usage
 
 ```js
-const rmFile = require('rm-file')
+import { rmFile } from 'rm-file'
 
-rmFile('useless-file.txt').then(() => {
-  console.log('File removed')
-})
+await rmFile('useless-file.txt')
+```
+
+### Sync
+
+```js
+import { rmFileSync } from 'rm-file'
+
+rmFileSync('useless-file.txt')
 ```
 
 ## API
 
-### rmFile(path)
+### `rmFile(path)`
 
-Returns a `Promise`.
+- `path` (`string | Buffer | URL`, required)
+- returns `Promise<void>`
 
-### rmFile.sync(path)
+### `rmFileSync(path)`
 
-#### path
-
-Type: `string`
-
-File you want to remove.
+- `path` (`string | Buffer | URL`, required)
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -1,18 +1,18 @@
 /* eslint-env mocha */
 
-'use strict'
+import assert from 'assert'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
 
-const fs = require('fs')
-const path = require('path')
-const assert = require('assert')
+import { rmFile, rmFileSync } from './index.js'
 
-const assertRejects = require('assert-rejects')
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
 
-const rmFile = require('./')
-
-describe('rm-file', () => {
+describe('rmFile', () => {
   it('removes a file', () => {
-    const target = path.join(__dirname, '460BF8B4-E631-4091-9B7C-7F42031145F1')
+    const target = path.join(dirname, '460BF8B4-E631-4091-9B7C-7F42031145F1')
 
     fs.writeFileSync(target, '')
 
@@ -24,7 +24,7 @@ describe('rm-file', () => {
   it('gives good ENOENT error', () => {
     const target = '/B7F5FA65-2D78-4AC2-82CF-BAF484A34A30'
 
-    return assertRejects(
+    return assert.rejects(
       rmFile(target),
       err => (
         err.code === 'ENOENT' &&
@@ -35,9 +35,9 @@ describe('rm-file', () => {
   })
 
   it('gives good ENOTDIR error', () => {
-    const target = path.join(__filename, 'my-file')
+    const target = path.join(filename, 'my-file')
 
-    return assertRejects(
+    return assert.rejects(
       rmFile(target),
       err => (
         err.code === 'ENOTDIR' &&
@@ -48,13 +48,13 @@ describe('rm-file', () => {
   })
 })
 
-describe('rm-file.sync', () => {
+describe('rmFileSync', () => {
   it('removes a file', () => {
-    const target = path.join(__dirname, '460BF8B4-E631-4091-9B7C-7F42031145F1')
+    const target = path.join(dirname, '460BF8B4-E631-4091-9B7C-7F42031145F1')
 
     fs.writeFileSync(target, '')
 
-    rmFile.sync(target)
+    rmFileSync(target)
     assert.strictEqual(fs.existsSync(target), false, `The file "${target}" should have been removed`)
   })
 
@@ -62,7 +62,7 @@ describe('rm-file.sync', () => {
     const target = '/B7F5FA65-2D78-4AC2-82CF-BAF484A34A31'
 
     assert.throws(
-      () => rmFile.sync(target),
+      () => rmFileSync(target),
       err => (
         err.code === 'ENOENT' &&
         err.path === target &&
@@ -72,10 +72,10 @@ describe('rm-file.sync', () => {
   })
 
   it('gives good ENOTDIR error', () => {
-    const target = path.join(__filename, 'my-file')
+    const target = path.join(filename, 'my-file')
 
     assert.throws(
-      () => rmFile.sync(target),
+      () => rmFileSync(target),
       err => (
         err.code === 'ENOTDIR' &&
         err.path === target &&


### PR DESCRIPTION
Migration Guide:

This relases changes the package from a Common JS module to an EcmaScript module, and drops support for older versions of Node.

- The minimum version of Node.js supported is now: `12.20.0`, `14.13.1`, and `16.0.0`
- The package must now be imported using the native `import` syntax instead of with `require`